### PR TITLE
Fix comments definition for the mode.

### DIFF
--- a/less-css-mode.el
+++ b/less-css-mode.el
@@ -160,7 +160,9 @@ Special commands:
   (modify-syntax-entry ?/ "< 124b" less-css-mode-syntax-table)
   (modify-syntax-entry ?\n "> b" less-css-mode-syntax-table)
   (set (make-local-variable 'comment-start) "//")
+  (set (make-local-variable 'comment-start-skip) "//[ \t]*")
   (set (make-local-variable 'comment-end) "")
+  (set (make-local-variable 'comment-end-skip) "")
 
   (add-hook 'after-save-hook 'less-css-compile-maybe nil t))
 


### PR DESCRIPTION
I am not sure about if comments work in Emacs 23, but when I use less-css-mode in Emacs 24 comments-dwim function does not work properly and comments do not have highlighted.

This fix just defines comments-end-skip and comments-start-skip variables according to the '//' style. They are defined in css-mode to work with '/\* */' comments.
