### PR TITLE
Improve support of the css-mode of Emacs HEAD

### DIFF
--- a/less-css-mode.el
+++ b/less-css-mode.el
@@ -66,7 +66,8 @@
 ;; Landström or Garshol
 
 (require 'css-mode)
-(unless (boundp 'css-navigation-syntax-table)
+(unless (or (boundp 'css-navigation-syntax-table)
+            (functionp 'css-smie-rules))
   (error "Wrong css-mode.el: please use the version by Stefan Monnier, bundled with Emacs >= 23."))
 
 (defgroup less-css nil


### PR DESCRIPTION
The css-mode came to use the SMIE now.

see: http://git.savannah.gnu.org/cgit/emacs.git/commit/lisp/textmodes/css-mode.el?id=0c89e81a86799e0f2226d5ad59e9582d5aefd82c
