### PR TITLE
Adds `less-css-input-file-name` option; Changes `compile` to `shell-command`

### DIFF
--- a/less-css-mode.el
+++ b/less-css-mode.el
@@ -159,7 +159,7 @@ default.")
   "Compiles the current buffer to css using `less-css-lessc-command'."
   (interactive)
   (message "Compiling less to css")
-  (compile
+  (shell-command
    (mapconcat 'identity
               (append (list (less-css--maybe-shell-quote-command less-css-lessc-command))
                       less-css-lessc-options


### PR DESCRIPTION
The purpose of `less-css-input-file-name` option is to make possible to compile another file on save. It was useful for me, when I edited `variables.less` that was included in `style.less`, so I actually needed `style.less` to be compiled to `style.css`.

Also I found it quite annoying that `*compilation*` buffer opened every time on save :) I didn't find a way to prevent this behaviour of `compile` function, but I learned that `shell-command` wouldn't open an extra buffer if command exited with no output. Though it should open a buffer if there were errors or warnings.
