### PR TITLE
Global default setting for an output directory

### DIFF
--- a/less-css-mode.el
+++ b/less-css-mode.el
@@ -99,6 +99,15 @@ Use \"-x\" to minify output."
   :type '(repeat string)
   :group 'less-css)
 
+(defcustom less-css-default-output-directory nil
+  "Default directory in which to save CSS, or nil to use the LESS file's directory.
+
+This path is expanded relative to the directory of the LESS file
+using `expand-file-name', so both relative and absolute paths
+will work as expected."
+  :type 'string
+  :group 'less-css)
+
 (defvar less-css-output-directory nil
   "Directory in which to save CSS, or nil to use the LESS file's directory.
 
@@ -159,7 +168,7 @@ default.
   "Calculate the path for the compiled CSS file created by `less-css-compile'."
   (expand-file-name (or less-css-output-file-name
                         (concat (file-name-nondirectory (file-name-sans-extension buffer-file-name)) ".css"))
-                    (or less-css-output-directory default-directory)))
+                    (or less-css-default-output-directory less-css-output-directory default-directory)))
 
 (defun less-css--maybe-shell-quote-command (command)
   "Selectively shell-quote COMMAND appropriately for `system-type'."


### PR DESCRIPTION
Hi.
After I started using less-css-mode, which I find really helpful, I ended up specifying same output directory comment in my less files as in most cases my css files where places under relative "../css" folder. So I thought it would be nice to have global setting for such case and only overwrite output directory in comments if needed.
Thank you.
