### PR TITLE
Removed output redirect

### DIFF
--- a/less-css-mode.el
+++ b/less-css-mode.el
@@ -185,7 +185,6 @@ default.")
                               less-css-lessc-options
                               (list (shell-quote-argument
                                      (or less-css-input-file-name buffer-file-name))
-                                    ">"
                                     (shell-quote-argument (less-css--output-path))))
                       " "))
         (add-hook 'compilation-finish-functions


### PR DESCRIPTION
Suppose I want to generate a source-map on compile:

``` lisp
(setq less-css-compile-at-save t
        less-css-lessc-options '("--source-map" "--no-color"))
```

Current version will call lessc as follows:

``` sh
lessc --source-map --no-color main.less > main.css
```

But generated file will have:

```
the sourcemap option only has an optional filename if the css filename is given
consider adding --source-map-map-inline which embeds the sourcemap into the css
```

So to fix this I have to remove redirect from call to `lessc`.
